### PR TITLE
Metaconfiguration support

### DIFF
--- a/configurations/csu-klasifikace.ttl
+++ b/configurations/csu-klasifikace.ttl
@@ -5,6 +5,8 @@
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix xkos: <http://rdf-vocabulary.ddialliance.org/xkos#> .
 @prefix browser-csu: <https://linked.opendata.cz/resource/vocabulary/knowledge-graph-browser/čsú/> .
+@prefix void: <http://rdfs.org/ns/void#> .
+
 
 # https://linked.opendata.cz/resource/knowledge-graph-browser/configuration/čsú-klasifikace
 # https://linked.opendata.cz/resource/knowledge-graph-browser/čsú-klasifikace/style-sheet
@@ -15,7 +17,10 @@
 #####################################
 
 <https://linked.opendata.cz/resource/knowledge-graph-browser/configuration/čsú-klasifikace> a browser:Configuration ;
-  dct:title "Konfigurace procházení klasifikací ČSÚ"@cs ;
+  dct:title "Klasifikace ČSÚ"@cs,
+    "Czech Statistical Office classification"@en;
+  browser:hasVisualStyleSheet <https://linked.opendata.cz/resource/knowledge-graph-browser/čsú-klasifikace/style-sheet>;
+  browser:startingNode <https://linked.opendata.cz/resource/knowledge-graph-browser/configuration/čsú-klasifikace>;
   browser:hasViewSet <https://linked.opendata.cz/resource/knowledge-graph-browser/view-set/čsú-klasifikace/klasifikace>, <https://linked.opendata.cz/resource/knowledge-graph-browser/view-set/čsú-klasifikace/úroveň>, <https://linked.opendata.cz/resource/knowledge-graph-browser/view-set/čsú-klasifikace/prvek> .
 
 #####################################

--- a/configurations/metaconfiguration.ttl
+++ b/configurations/metaconfiguration.ttl
@@ -5,6 +5,9 @@
   dct:title
     "Supported configurations"@en,
     "Podporované konfigurace"@cs ;
+  dct:description
+    "List of all supported cofigurations of the knowledge graph browser."@en,
+    "Seznam všech podporovaných konfigurací knowledge graph browseru."@cs ;
   browser:hasMetaConficuration
     <https://linked.opendata.cz/resource/knowledge-graph-browser/meta-configuration/czech-government>,
     <https://linked.opendata.cz/resource/knowledge-graph-browser/meta-configuration/wikidata> .

--- a/configurations/metaconfiguration.ttl
+++ b/configurations/metaconfiguration.ttl
@@ -1,0 +1,39 @@
+@prefix browser: <https://linked.opendata.cz/ontology/knowledge-graph-browser/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+
+<https://linked.opendata.cz/resource/knowledge-graph-browser/metaconfiguration/all-configurations> a browser:MetaConfiguration ;
+  dct:title
+    "Supported configurations"@en,
+    "Podporované konfigurace"@cs ;
+  browser:hasMetaconficuration
+    <https://linked.opendata.cz/resource/knowledge-graph-browser/metaconfiguration/czech-government>,
+    <https://linked.opendata.cz/resource/knowledge-graph-browser/metaconfiguration/wikidata> .
+
+<https://linked.opendata.cz/resource/knowledge-graph-browser/metaconfiguration/czech-government> a browser:MetaConfiguration ;
+  dct:title
+    "Czech Government"@en,
+    "Správa České republiky"@cs ;
+  dct:description
+    "Open data of government institutions in the Czech Republic."@en,
+    "Otevřená data vládních institucí v ČR."@cs ;
+  browser:image "https://upload.wikimedia.org/wikipedia/commons/c/cb/Flag_of_the_Czech_Republic.svg" ;
+  browser:hasConfiguration
+    <https://linked.opendata.cz/resource/knowledge-graph-browser/configuration/čsú-klasifikace>,
+    <https://linked.opendata.cz/resource/knowledge-graph-browser/configuration/nkod>,
+    <https://linked.opendata.cz/resource/knowledge-graph-browser/configuration/sgov-skos>,
+    <https://linked.opendata.cz/resource/knowledge-graph-browser/configuration/skod>,
+    <https://linked.opendata.cz/resource/knowledge-graph-browser/configuration/rpp>,
+    <https://linked.opendata.cz/resource/knowledge-graph-browser/configuration/psp>,
+    <https://linked.opendata.cz/resource/knowledge-graph-browser/configuration/sgov> .
+
+<https://linked.opendata.cz/resource/knowledge-graph-browser/metaconfiguration/wikidata> a browser:MetaConfiguration ;
+  dct:title
+    "Wikidata"@en,
+    "Wikidata"@cs ;
+  dct:description
+    "Data from largest online encyclopedia."@en,
+    "Data největší online encyklopedie."@cs ;
+  browser:image "https://upload.wikimedia.org/wikipedia/en/8/80/Wikipedia-logo-v2.svg" ;
+  browser:hasConfiguration
+    <https://linked.opendata.cz/resource/knowledge-graph-browser/configuration/wikidata/animals>,
+    <https://linked.opendata.cz/resource/knowledge-graph-browser/configuration/wikidata/people> .

--- a/configurations/metaconfiguration.ttl
+++ b/configurations/metaconfiguration.ttl
@@ -1,15 +1,15 @@
 @prefix browser: <https://linked.opendata.cz/ontology/knowledge-graph-browser/> .
 @prefix dct: <http://purl.org/dc/terms/> .
 
-<https://linked.opendata.cz/resource/knowledge-graph-browser/metaconfiguration/all-configurations> a browser:MetaConfiguration ;
+<https://linked.opendata.cz/resource/knowledge-graph-browser/meta-configuration/all-configurations> a browser:MetaConfiguration ;
   dct:title
     "Supported configurations"@en,
     "Podporované konfigurace"@cs ;
-  browser:hasMetaconficuration
-    <https://linked.opendata.cz/resource/knowledge-graph-browser/metaconfiguration/czech-government>,
-    <https://linked.opendata.cz/resource/knowledge-graph-browser/metaconfiguration/wikidata> .
+  browser:hasMetaConficuration
+    <https://linked.opendata.cz/resource/knowledge-graph-browser/meta-configuration/czech-government>,
+    <https://linked.opendata.cz/resource/knowledge-graph-browser/meta-configuration/wikidata> .
 
-<https://linked.opendata.cz/resource/knowledge-graph-browser/metaconfiguration/czech-government> a browser:MetaConfiguration ;
+<https://linked.opendata.cz/resource/knowledge-graph-browser/meta-configuration/czech-government> a browser:MetaConfiguration ;
   dct:title
     "Czech Government"@en,
     "Správa České republiky"@cs ;
@@ -26,7 +26,7 @@
     <https://linked.opendata.cz/resource/knowledge-graph-browser/configuration/psp>,
     <https://linked.opendata.cz/resource/knowledge-graph-browser/configuration/sgov> .
 
-<https://linked.opendata.cz/resource/knowledge-graph-browser/metaconfiguration/wikidata> a browser:MetaConfiguration ;
+<https://linked.opendata.cz/resource/knowledge-graph-browser/meta-configuration/wikidata> a browser:MetaConfiguration ;
   dct:title
     "Wikidata"@en,
     "Wikidata"@cs ;

--- a/configurations/nkod.ttl
+++ b/configurations/nkod.ttl
@@ -16,7 +16,10 @@
 # https://rpp-opendata.egon.gov.cz/odrpp/zdroj/orgán-veřejné-moci/00025593
 
 <https://linked.opendata.cz/resource/knowledge-graph-browser/configuration/nkod> a browser:Configuration ;
-  dct:title "Konfigurace procházení národního katalogu otevřených dat"@cs ;
+  dct:title "Národní katalog otevřených dat"@cs,
+    "National Catalog of Open Data (NKOD)"@en ;
+  browser:hasVisualStyleSheet <https://linked.opendata.cz/resource/knowledge-graph-browser/nkod/style-sheet>;
+  browser:startingNode <https://rpp-opendata.egon.gov.cz/odrpp/zdroj/orgán-veřejné-moci/00025593>;
   browser:hasViewSet <https://linked.opendata.cz/resource/knowledge-graph-browser/view-set/nkod/katalog>, <https://linked.opendata.cz/resource/knowledge-graph-browser/view-set/nkod/poskytovatel>, <https://linked.opendata.cz/resource/knowledge-graph-browser/view-set/rpp/kategorieovm>, <https://linked.opendata.cz/resource/knowledge-graph-browser/view-set/rpp/ovm> .
 
 #####################################

--- a/configurations/psp.ttl
+++ b/configurations/psp.ttl
@@ -11,7 +11,11 @@
 #####################################
 
 <https://linked.opendata.cz/resource/knowledge-graph-browser/configuration/psp> a browser:Configuration ;
-  dct:title "Konfigurace procházení dat Poslanecké sněmovny Parlamentu České republiky"@cs ;
+  dct:title "Poslanecká sněmovna parlamentu České republiky"@cs,
+    "Chamber of deputies - Parliament of the Czech Republic"@en;
+  browser:hasVisualStyleSheet <https://linked.opendata.cz/resource/knowledge-graph-browser/psp/style-sheet>;
+  browser:startingNode <https://psp.opendata.cz/zdroj/osoba/5914>;
+  browser:resourceIriPattern "^https://psp\\.opendata\\.cz/zdroj/";
   browser:hasViewSet <https://linked.opendata.cz/resource/knowledge-graph-browser/view-set/psp/tisk> ;
   browser:hasViewSet <https://linked.opendata.cz/resource/knowledge-graph-browser/view-set/psp/poslanec> .
 

--- a/configurations/rpp.ttl
+++ b/configurations/rpp.ttl
@@ -11,7 +11,10 @@
 #####################################
 
 <https://linked.opendata.cz/resource/knowledge-graph-browser/configuration/rpp> a browser:Configuration ;
-  dct:title "Konfigurace procházení registru práv a povinností"@cs ;
+  dct:title "Registr práv a povinností"@cs,
+    "Register of rights and obligations of the Czech Republic"@en;
+  browser:hasVisualStyleSheet <https://linked.opendata.cz/resource/knowledge-graph-browser/rpp/style-sheet>;
+  browser:resourceIriPattern "^https://rpp-opendata\\.egon\\.gov\\.cz/";
   browser:autocomplete <https://raw.githubusercontent.com/martinnec/kgbrowser/master/configurations/rpp-autocomplete.json> ;
   browser:hasViewSet <https://linked.opendata.cz/resource/knowledge-graph-browser/view-set/rpp/agenda>,
     <https://linked.opendata.cz/resource/knowledge-graph-browser/view-set/rpp/činnost>,

--- a/configurations/sgov-skos.ttl
+++ b/configurations/sgov-skos.ttl
@@ -17,6 +17,8 @@
 
 <https://linked.opendata.cz/resource/knowledge-graph-browser/configuration/sgov-skos> a browser:Configuration ;
   dct:title "Konfigurace procházení slovníku vyjádřeného jako SKOS"@cs ;
+  browser:hasVisualStyleSheet <https://linked.opendata.cz/resource/knowledge-graph-browser/sgov-skos/style-sheet>;
+  browser:startingNode <https://slovník.gov.cz/generický/turistické-cíle/pojem/turistický-cíl>;
   browser:hasViewSet <https://linked.opendata.cz/resource/knowledge-graph-browser/view-set/sgov-skos/scheme>, <https://linked.opendata.cz/resource/knowledge-graph-browser/view-set/sgov-skos/concept> .
 
 #####################################

--- a/configurations/sgov.ttl
+++ b/configurations/sgov.ttl
@@ -16,8 +16,11 @@
 #####################################
 
 <https://linked.opendata.cz/resource/knowledge-graph-browser/configuration/sgov> a browser:Configuration ;
-  dct:title "Configuration of SGOV browser"@en ;
+  dct:title "Semantic dictionary of terms (SGOV)"@en,
+    "Sémantický slovník pojmů (SGOV)"@cs;
   browser:autocomplete <https://raw.githubusercontent.com/martinnec/kgbrowser/master/configurations/sgov-autocomplete.json> ;
+  browser:hasVisualStyleSheet <https://linked.opendata.cz/resource/knowledge-graph-browser/sgov/style-sheet>;
+  browser:resourceIriPattern "^https://slovník\\.gov\\.cz/";
   browser:hasViewSet <https://linked.opendata.cz/resource/knowledge-graph-browser/view-set/sgov/object-type>,
     <https://linked.opendata.cz/resource/knowledge-graph-browser/view-set/sgov/trobe-type>,
     <https://linked.opendata.cz/resource/knowledge-graph-browser/view-set/sgov/relation-type>,

--- a/configurations/skod.ttl
+++ b/configurations/skod.ttl
@@ -13,7 +13,9 @@
   #####################################
   
   <https://linked.opendata.cz/resource/knowledge-graph-browser/configuration/skod> a browser:Configuration ;
-    dct:title "Configuration of SKOD browser"@en ;
+    dct:title "Configuration of SKOD browser"@en,
+      "Konfigurace SKOD browseru"@cs ;
+    browser:hasVisualStyleSheet <https://linked.opendata.cz/resource/knowledge-graph-browser/sgov/style-sheet>;
     browser:hasViewSet <https://linked.opendata.cz/resource/knowledge-graph-browser/view-set/skod/dataset>,
       <https://linked.opendata.cz/resource/knowledge-graph-browser/view-set/skod/item>,
       <https://linked.opendata.cz/resource/knowledge-graph-browser/view-set/sgov/object-type>,

--- a/configurations/wikidata-animals.ttl
+++ b/configurations/wikidata-animals.ttl
@@ -15,7 +15,14 @@
 #####################################
 
 <https://linked.opendata.cz/resource/knowledge-graph-browser/configuration/wikidata/animals> a browser:Configuration ;
-  dct:title "Configuration for browsing animals from Wikidata"@en ;
+  dct:title "Browsing animals and plants from Wikidata"@en,
+   "Procházení živočichů a rostlin z Wikipedie"@cs;
+  dct:description "Classification of all organisms, plants and animals, into taxa."@en,
+   "Možnost procházet sítí taxonů všech zvířat a rostil jež jsou na Wikipedii."@cs;
+  browser:hasVisualStyleSheet <https://linked.opendata.cz/resource/knowledge-graph-browser/wikidata/animals/style-sheet>;
+  browser:startingNode <http://www.wikidata.org/entity/Q7377>,
+   <http://www.wikidata.org/entity/Q192154>;
+  browser:resourceUriPattern "^http://www\.wikidata\.org/entity/Q[1-9][0-9]*$";
   browser:hasViewSet <https://linked.opendata.cz/resource/knowledge-graph-browser/view-set/wikidata/animals/taxon> .
 
 #####################################

--- a/configurations/wikidata-animals.ttl
+++ b/configurations/wikidata-animals.ttl
@@ -15,14 +15,14 @@
 #####################################
 
 <https://linked.opendata.cz/resource/knowledge-graph-browser/configuration/wikidata/animals> a browser:Configuration ;
-  dct:title "Browsing animals and plants from Wikidata"@en,
-   "Procházení živočichů a rostlin z Wikipedie"@cs;
+  dct:title "Taxonomy of animals and plants"@en,
+   "Taxonomie rostlin a živočichů"@cs;
   dct:description "Classification of all organisms, plants and animals, into taxa."@en,
    "Možnost procházet sítí taxonů všech zvířat a rostil jež jsou na Wikipedii."@cs;
   browser:hasVisualStyleSheet <https://linked.opendata.cz/resource/knowledge-graph-browser/wikidata/animals/style-sheet>;
   browser:startingNode <http://www.wikidata.org/entity/Q7377>,
    <http://www.wikidata.org/entity/Q192154>;
-  browser:resourceUriPattern "^http://www\.wikidata\.org/entity/Q[1-9][0-9]*$";
+  browser:resourceIriPattern "^http://www\\.wikidata\\.org/entity/Q[1-9][0-9]*$";
   browser:hasViewSet <https://linked.opendata.cz/resource/knowledge-graph-browser/view-set/wikidata/animals/taxon> .
 
 #####################################

--- a/configurations/wikidata-people.ttl
+++ b/configurations/wikidata-people.ttl
@@ -25,7 +25,15 @@
 #####################################
 
 <https://linked.opendata.cz/resource/knowledge-graph-browser/configuration/wikidata/people> a browser:Configuration ;
-  dct:title "Procházení lidí z Wikidata"@cs ;
+  dct:title "Slavné osobnosti"@cs,
+    "Famous personalities"@en;
+  dct:description "Procházení fimařů, herců a spisovatelů."@cs,
+    "Browsing through the film makers, actors and writers."@en;
+  browser:hasVisualStyleSheet <https://linked.opendata.cz/resource/knowledge-graph-browser/wikidata/people/style-sheet>;
+  browser:startingNode <http://www.wikidata.org/entity/Q80>, <http://www.wikidata.org/entity/Q92743>, <http://www.wikidata.org/entity/Q62843>,
+    <http://www.wikidata.org/entity/Q937>,
+    <http://www.wikidata.org/entity/Q7186>;
+  browser:resourceIriPattern "^http://www\\.wikidata\\.org/entity/Q[1-9][0-9]*$";
   browser:hasViewSet <https://linked.opendata.cz/resource/knowledge-graph-browser/view-set/wikidata/person>, <https://linked.opendata.cz/resource/knowledge-graph-browser/view-set/wikidata/place/people>, <https://linked.opendata.cz/resource/knowledge-graph-browser/view-set/wikidata/creative-work>, <https://linked.opendata.cz/resource/knowledge-graph-browser/view-set/wikidata/award>, <https://linked.opendata.cz/resource/knowledge-graph-browser/view-set/wikidata/discovery>, <https://linked.opendata.cz/resource/knowledge-graph-browser/view-set/wikidata/entity> .
 
 #####################################

--- a/kgserver.js
+++ b/kgserver.js
@@ -623,37 +623,37 @@ app.get('/stylesheet', function (req, res)  {
 });
 
 /**
- * Handles requests to get a metaconfiguration.
- * Metaconfiguration is like a directory for other metaconfigurations and configurations.
+ * Handles requests to get a meta configuration.
+ * Meta configuration is like a directory for other meta configurations and configurations.
  *
- * Returns the metaconfiguration, basic info about sub-metaconfigurations and full info about sub-configurations
+ * Returns the meta configuration, basic info about meta sub-configurations and full info about sub-configurations
  *
- * Parameters: iri Iri of the metaconfiguration
+ * Parameters: iri Iri of the meta configuration
  *             languages Comma separated ISO 639-1 languages. If there is not at least one literal for one given language, random (language) is returned.
  */
-app.get('/metaconfiguration', function (req, res) {
+app.get('/meta-configuration', function (req, res) {
     res.setHeader('Access-Control-Allow-Origin', '*');
-    const metaconfigurationIRI = req.query.iri;
+    const metaConfigurationIRI = req.query.iri;
     const languages = req.query.languages.split(",");
 
     let store = $rdf.graph();
-    const mconf = $rdf.sym(utf8ToUnicode(metaconfigurationIRI));
+    const mconf = $rdf.sym(utf8ToUnicode(metaConfigurationIRI));
     const fetcher = new $rdf.Fetcher(store);
 
     // Load the resource and its neighbours
-    fetcher.load(fetchableURI(metaconfigurationIRI)).then(response => {
+    fetcher.load(fetchableURI(metaConfigurationIRI)).then(response => {
         // Data sent to client
-        let result = getMetaconfigurationInfo(store, mconf, languages);
-        result.has_metaconfigurations = [];
+        let result = getMetaConfigurationInfo(store, mconf, languages);
+        result.has_meta_configurations = [];
         result.has_configurations = [];
 
         let promises = [];
 
-        // Process metaconfigurations
-        const childMConfs = store.each(mconf, BROWSER("hasMetaconficuration"));
+        // Process meta configurations
+        const childMConfs = store.each(mconf, BROWSER("hasMetaConficuration"));
         promises = promises.concat(childMConfs.map(childMConf => new Promise((resolve, reject) => {
             fetcher.load(fetchableURI(childMConf.value)).then(response => {
-                result.has_metaconfigurations.push(getMetaconfigurationInfo(store, childMConf, languages));
+                result.has_meta_configurations.push(getMetaConfigurationInfo(store, childMConf, languages));
                 resolve();
             });
         })));
@@ -676,7 +676,7 @@ app.get('/metaconfiguration', function (req, res) {
 
 /**
  * Handles requests to get a configuration.
- * Does not need to be used if the configuration was obtained from metaconfiguration query
+ * Does not need to be used if the configuration was obtained from meta configuration query
  *
  * Returns full info about sub-configuration
  *
@@ -703,15 +703,15 @@ app.get('/configuration', function (req, res) {
 });
 
 /**
- * Gives basic information about the metaconfiguration
+ * Gives basic information about the meta configuration
  */
-function getMetaconfigurationInfo(store, metaconfiguration, languages) {
-    const titleLiterals = store.each(metaconfiguration, DCT("title"));
-    const descriptionLiterals = store.each(metaconfiguration, DCT("description"));
-    const imageLiteral = store.any(metaconfiguration, BROWSER("image"));
+function getMetaConfigurationInfo(store, metaConfiguration, languages) {
+    const titleLiterals = store.each(metaConfiguration, DCT("title"));
+    const descriptionLiterals = store.each(metaConfiguration, DCT("description"));
+    const imageLiteral = store.any(metaConfiguration, BROWSER("image"));
 
     return {
-        iri: metaconfiguration.value,
+        iri: metaConfiguration.value,
         title: processLiteralsByLanguage(titleLiterals, languages),
         description: processLiteralsByLanguage(descriptionLiterals, languages),
         image: imageLiteral ? imageLiteral.value : null,

--- a/kgserver.js
+++ b/kgserver.js
@@ -622,6 +622,174 @@ app.get('/stylesheet', function (req, res)  {
                                     
 });
 
+/**
+ * Handles requests to get a metaconfiguration.
+ * Metaconfiguration is like a directory for other metaconfigurations and configurations.
+ *
+ * Returns the metaconfiguration, basic info about sub-metaconfigurations and full info about sub-configurations
+ *
+ * Parameters: iri Iri of the metaconfiguration
+ *             languages Comma separated ISO 639-1 languages. If there is not at least one literal for one given language, random (language) is returned.
+ */
+app.get('/metaconfiguration', function (req, res) {
+    res.setHeader('Access-Control-Allow-Origin', '*');
+    const metaconfigurationIRI = req.query.iri;
+    const languages = req.query.languages.split(",");
+
+    let store = $rdf.graph();
+    const mconf = $rdf.sym(utf8ToUnicode(metaconfigurationIRI));
+    const fetcher = new $rdf.Fetcher(store);
+
+    // Load the resource and its neighbours
+    fetcher.load(fetchableURI(metaconfigurationIRI)).then(response => {
+        // Data sent to client
+        let result = getMetaconfigurationInfo(store, mconf, languages);
+        result.has_metaconfigurations = [];
+        result.has_configurations = [];
+
+        let promises = [];
+
+        // Process metaconfigurations
+        const childMConfs = store.each(mconf, BROWSER("hasMetaconficuration"));
+        promises = promises.concat(childMConfs.map(childMConf => new Promise((resolve, reject) => {
+            fetcher.load(fetchableURI(childMConf.value)).then(response => {
+                result.has_metaconfigurations.push(getMetaconfigurationInfo(store, childMConf, languages));
+                resolve();
+            });
+        })));
+
+        // Process configurations
+        const childConfs = store.each(mconf, BROWSER("hasConfiguration"));
+        promises = promises.concat(childConfs.map(childConf => new Promise((resolve, reject) => {
+            fetcher.load(fetchableURI(childConf.value)).then(response => {
+                result.has_configurations.push(getConfigurationInfo(store, childConf, languages));
+                resolve();
+            });
+        })));
+
+        Promise.all(promises).then(response => {
+            res.contentType('application/json');
+            res.send(JSON.stringify(result));
+        });
+    });
+});
+
+/**
+ * Handles requests to get a configuration.
+ * Does not need to be used if the configuration was obtained from metaconfiguration query
+ *
+ * Returns full info about sub-configuration
+ *
+ * Parameters: iri Iri of the configuration
+ *             languages Comma separated ISO 639-1 languages. If there is not at least one literal for one given language, random (language) is returned.
+ */
+app.get('/configuration', function (req, res) {
+    res.setHeader('Access-Control-Allow-Origin', '*');
+    const configurationIRI = req.query.iri;
+    const languages = req.query.languages.split(",");
+
+    let store = $rdf.graph();
+    const conf = $rdf.sym(utf8ToUnicode(configurationIRI));
+    const fetcher = new $rdf.Fetcher(store);
+
+    // Load the resource and its neighbours
+    fetcher.load(fetchableURI(configurationIRI)).then(response => {
+        // Data sent to client
+        let result = getConfigurationInfo(store, conf, languages);
+
+        res.contentType('application/json');
+        res.send(JSON.stringify(result));
+    });
+});
+
+/**
+ * Gives basic information about the metaconfiguration
+ */
+function getMetaconfigurationInfo(store, metaconfiguration, languages) {
+    const titleLiterals = store.each(metaconfiguration, DCT("title"));
+    const descriptionLiterals = store.each(metaconfiguration, DCT("description"));
+    const imageLiteral = store.any(metaconfiguration, BROWSER("image"));
+
+    return {
+        iri: metaconfiguration.value,
+        title: processLiteralsByLanguage(titleLiterals, languages),
+        description: processLiteralsByLanguage(descriptionLiterals, languages),
+        image: imageLiteral ? imageLiteral.value : null,
+    };
+}
+
+/**
+ * Gives basic information about the configuration
+ */
+function getConfigurationInfo(store, configuration, languages) {
+    let result = {
+        // Configuration IRI
+        iri: configuration.value,
+        // Stylesheet IRI
+        stylesheet: [],
+        title: {},
+        description: {},
+        // List of .json files
+        autocomplete: [],
+        starting_node: [],
+        // Regular expression how resource uri looks like
+        resource_pattern: null,
+/*        // For constructing resource IRI from ID (For example wikidata Q12345)
+        resource_id_pattern: null, /*{
+            before: string,
+            after: string,
+            id_pattern: regex,
+        }*/
+    };
+
+    const stylesheet = store.any(configuration, BROWSER("hasVisualStyleSheet"));
+    if (stylesheet) result.stylesheet = [stylesheet.value];
+
+    const titleLiterals = store.each(configuration, DCT("title"));
+    result.title = processLiteralsByLanguage(titleLiterals, languages);
+
+    const descriptionLiterals = store.each(configuration, DCT("description"));
+    result.description = processLiteralsByLanguage(descriptionLiterals, languages);
+
+    const autocompletes = store.each(configuration, BROWSER("autocomplete"));
+    autocompletes.forEach(autocomplete => result.autocomplete.push(autocomplete.value));
+
+    const startingNodes = store.each(configuration, BROWSER("startingNode"));
+    startingNodes.forEach(node => result.start_node.push(node.value));
+
+    const uri = store.any(configuration, BROWSER("resourceUriPattern"));
+    if (uri) result.resource_pattern = uri.value;
+
+    return result;
+}
+
+/**
+ * Takes list of literals and creates an object like {en: "apple", cs: "jablko"} for specified languages.
+ * @param {literal[]} literals
+ * @param {string[]} languages
+ * @return {{[lang: string]: string}}
+ */
+function processLiteralsByLanguage(literals, languages) {
+    let foundAny = false;
+    let result = {};
+
+    for (var i = 0; i < languages.length; i++) {
+        var literal = literals.find(literal => literal.language == languages[i]);
+        if (literal) {
+            result[languages[i]] = literal.value;
+            foundAny = true;
+        } else {
+            result[languages[i]] = null;
+        }
+    }
+
+    if (!foundAny && literals.length) {
+        result[literals[0].language] = literals[0].value;
+    }
+
+    return result;
+}
+
 app.listen(port, () => console.log(`Knowledge graph browser server listening on port ${port}!`));
 
 function fetchableURI(source) {

--- a/kgserver.js
+++ b/kgserver.js
@@ -734,12 +734,6 @@ function getConfigurationInfo(store, configuration, languages) {
         starting_node: [],
         // Regular expression how resource uri looks like
         resource_pattern: null,
-/*        // For constructing resource IRI from ID (For example wikidata Q12345)
-        resource_id_pattern: null, /*{
-            before: string,
-            after: string,
-            id_pattern: regex,
-        }*/
     };
 
     const stylesheet = store.any(configuration, BROWSER("hasVisualStyleSheet"));
@@ -755,9 +749,9 @@ function getConfigurationInfo(store, configuration, languages) {
     autocompletes.forEach(autocomplete => result.autocomplete.push(autocomplete.value));
 
     const startingNodes = store.each(configuration, BROWSER("startingNode"));
-    startingNodes.forEach(node => result.start_node.push(node.value));
+    startingNodes.forEach(node => result.starting_node.push(node.value));
 
-    const uri = store.any(configuration, BROWSER("resourceUriPattern"));
+    const uri = store.any(configuration, BROWSER("resourceIriPattern"));
     if (uri) result.resource_pattern = uri.value;
 
     return result;
@@ -767,7 +761,7 @@ function getConfigurationInfo(store, configuration, languages) {
  * Takes list of literals and creates an object like {en: "apple", cs: "jablko"} for specified languages.
  * @param {literal[]} literals
  * @param {string[]} languages
- * @return {{[lang: string]: string}}
+ * @return {{[lang: string]: string|null}}
  */
 function processLiteralsByLanguage(literals, languages) {
     let foundAny = false;
@@ -777,7 +771,7 @@ function processLiteralsByLanguage(literals, languages) {
         var literal = literals.find(literal => literal.language == languages[i]);
         if (literal) {
             result[languages[i]] = literal.value;
-            foundAny = true;
+            if (literal.value !== null) foundAny = true;
         } else {
             result[languages[i]] = null;
         }


### PR DESCRIPTION
This PR introduces metaconfigurations and small changes regarding configurations.

Metaconfiguration is used as a directory for both configurations and metaconfigurations, therefore allowing you to categorize configurations into multiple levels of directories. Each metaconfiguration has title, description and image (hope this is ok with you).

Also I want to put all necessary data into the configuration, as you can see in `wikidata-animals.ttl`. All this allow us to have only one IRI to metaconfiguration bundled with the client code and end users does not need to work with concepts as "stylesheet IRI" or "starting node IRI".

This PR is not yet finished.

![image](https://user-images.githubusercontent.com/23003372/86657445-87ce8d00-bfe8-11ea-9f41-940964ebbc5a.png)

---

![image](https://user-images.githubusercontent.com/23003372/86657734-c3695700-bfe8-11ea-86fd-768ee8ca70cc.png)


